### PR TITLE
Fix aria2 install location dependency

### DIFF
--- a/src/varia.in
+++ b/src/varia.in
@@ -2,5 +2,5 @@
 download_dir=$(xdg-user-dir DOWNLOAD)
 pythonexec='@PYTHON@'
 pkgdatadir='@pkgdatadir@'
-$pkgdatadir/../../aria2/aria2c -d $download_dir --enable-rpc --rpc-listen-port=6801 &
+aria2c -d $download_dir --enable-rpc --rpc-listen-port=6801 &
 $pythonexec $pkgdatadir/../../bin/varia-py.py


### PR DESCRIPTION
There's no reason to execute aria2c using a relative file path. If aria2 was installed correctly it should be accessible via the system PATH