### PR TITLE
Remove install location dependency from launch script

### DIFF
--- a/src/varia.in
+++ b/src/varia.in
@@ -1,4 +1,5 @@
 #!/bin/bash
 pythonexec='@PYTHON@'
-/app/bin/aria2c --enable-rpc --rpc-listen-port=6801 &
-$pythonexec /app/bin/varia-py.py
+pkgdatadir='@pkgdatadir@'
+$pkgdatadir/../../bin/aria2/aria2c --enable-rpc --rpc-listen-port=6801 &
+$pythonexec $pkgdatadir/../../bin/varia-py.py


### PR DESCRIPTION
Modification of #17 to _actually_ fix install location dependency while keeping relative file paths for flatpak build.