### PR TITLE
Remove extra appdir assignment linking to /var

### DIFF
--- a/src/variamain.py
+++ b/src/variamain.py
@@ -31,7 +31,6 @@ class MainWindow(Gtk.Window):
 
         self.appconf = {'download_speed_limit_enabled': '0', 'download_speed_limit': '0', 'auth': '0', 'auth_username': '', 'auth_password': '', 'download_directory': GLib.get_user_special_dir(GLib.USER_DIRECTORY_DOWNLOAD)}
         self.downloaddir = GLib.get_user_special_dir(GLib.USER_DIRECTORY_DOWNLOAD)
-        self.appdir = os.path.join('/var', 'data')
 
         if os.path.exists(os.path.join(self.appdir, 'varia.conf')):
             with open(os.path.join(self.appdir, 'varia.conf'), 'r') as f:


### PR DESCRIPTION
I appreciate the effort to get it working outside of flatpak, though this seems to have been left in by mistake resulting in a hard reference to /var rather than the user's home directory. 

Since it doesn't currently work outside of flatpak without this I'd recommend a new release with the fix asap. I'll update the AUR pkgbuild when that new release is available and it will finally be patch free :)