### PR TITLE
Check if Downloads are Older than the Browser Session

### DIFF
--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -1,3 +1,5 @@
+let startTime = Date.now();
+
 chrome.runtime.onInstalled.addListener(function(details) {
   if (details.reason === 'install') {
     chrome.storage.sync.set({enabled: true});
@@ -5,6 +7,11 @@ chrome.runtime.onInstalled.addListener(function(details) {
 });
 
 chrome.downloads.onCreated.addListener(function(downloadItem) {
+  var downloadTime = new Date(downloadItem.startTime).getTime();
+  if (downloadTime < startTime) {
+    return;
+  }
+
   chrome.storage.sync.get('enabled', function(data) {
     if (data.enabled) {
       sendToAria2(downloadItem);


### PR DESCRIPTION
Closes #110.
Currently, a behavior quirk in Chromium causes the entire download history to be sent to Varia. This PR fixes that by getting the current time at extension startup, then checking the new download's start time against the extension start time to make sure it isn't older than the current browser session.