### PR TITLE
Add "Download with Varia" Context Menu Button

### DIFF
--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -1,39 +1,99 @@
 let startTime = Date.now();
 
-chrome.runtime.onInstalled.addListener(function(details) {
-  if (details.reason === 'install') {
-    chrome.storage.sync.set({enabled: true});
+chrome.runtime.onInstalled.addListener(function (details) {
+  if (details.reason === "install") {
+    chrome.storage.sync.set({ enabled: true });
   }
 });
 
-chrome.downloads.onCreated.addListener(function(downloadItem) {
+chrome.downloads.onCreated.addListener(function (downloadItem) {
   var downloadTime = new Date(downloadItem.startTime).getTime();
   if (downloadTime < startTime) {
     return;
   }
 
-  chrome.storage.sync.get('enabled', function(data) {
+  chrome.storage.sync.get("enabled", function (data) {
     if (data.enabled) {
       sendToAria2(downloadItem);
     }
   });
 });
 
+chrome.tabs.onActivated.addListener(async function (activeInfo) {
+  try {
+    if ("mozInnerScreenX" in window) {
+      // Thanks Firefox...:')
+      tab = await browser.tabs.get(activeInfo.tabId);
+    } else {
+      tab = await chrome.tabs.get(activeInfo.tabId);
+    }
+
+    if (tab.url != "") {
+      handleContextMenu(tab);
+    }
+  } catch (error) {
+    console.error(error);
+  }
+});
+
+chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
+  handleContextMenu(tab);
+});
+
+chrome.contextMenus.onClicked.addListener(function (info, tab) {
+  if (info.menuItemId == "varia-video-download") {
+    sendVideoToAria(tab.url);
+  }
+});
+
+async function handleContextMenu(tab) {
+  if (tab.url.includes("youtube.com/watch")) {
+    chrome.contextMenus.create({
+      title: "Download video with Varia",
+      id: "varia-video-download",
+    });
+  } else {
+    try {
+      await chrome.contextMenus.remove("varia-video-download");
+    } catch (error) {
+      console.log("No menu item.");
+    }
+  }
+}
+
 function sendToAria2(downloadItem) {
-  fetch('http://localhost:6801/jsonrpc', {
-    method: 'POST',
+  fetch("http://localhost:6801/jsonrpc", {
+    method: "POST",
     headers: {
-      'Content-Type': 'application/json'
+      "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      jsonrpc: '2.0',
-      id: '1',
-      method: 'aria2.addUri',
-      params: [[downloadItem.url], {"pause": "true"}]
+      jsonrpc: "2.0",
+      id: "1",
+      method: "aria2.addUri",
+      params: [[downloadItem.url], { pause: "true" }],
+    }),
+  })
+    .then((response) => {
+      chrome.downloads.cancel(downloadItem.id);
     })
-  }).then(response => {
-    chrome.downloads.cancel(downloadItem.id);
-  }).catch(error => {
+    .catch((error) => {});
+}
 
-  });
+function sendVideoToAria(url) {
+  fetch("http://localhost:6803/video", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      url: url,
+    }),
+  })
+    .then((response) => {
+      console.log("Sent video to Varia");
+    })
+    .catch((error) => {
+      console.error(error);
+    });
 }

--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -49,7 +49,7 @@ chrome.contextMenus.onClicked.addListener(function (info, tab) {
 async function handleContextMenu(tab) {
   if (tab.url.includes("youtube.com/watch")) {
     chrome.contextMenus.create({
-      title: "Download video with Varia",
+      title: "Download with Varia...",
       id: "varia-video-download",
     });
   } else {

--- a/browser-extension/manifest-chromium.json
+++ b/browser-extension/manifest-chromium.json
@@ -11,7 +11,10 @@
     "default_popup": "popup.html"
   },
   "permissions": ["downloads", "storage", "contextMenus", "tabs"],
-  "host_permissions": ["http://localhost:6801/jsonrpc"],
+  "host_permissions": [
+    "http://localhost:6801/jsonrpc",
+    "http://localhost:6803/video"
+  ],
   "manifest_version": 3,
   "background": {
     "service_worker": "background.js"

--- a/browser-extension/manifest-chromium.json
+++ b/browser-extension/manifest-chromium.json
@@ -10,11 +10,10 @@
   "action": {
     "default_popup": "popup.html"
   },
-  "permissions": ["downloads", "storage"],
+  "permissions": ["downloads", "storage", "contextMenus", "tabs"],
   "host_permissions": ["http://localhost:6801/jsonrpc"],
   "manifest_version": 3,
   "background": {
     "service_worker": "background.js"
   }
 }
-

--- a/browser-extension/manifest-firefox.json
+++ b/browser-extension/manifest-firefox.json
@@ -10,7 +10,7 @@
   "browser_action": {
     "default_popup": "popup.html"
   },
-  "permissions": ["downloads", "storage", "<all_urls>"],
+  "permissions": ["downloads", "storage", "<all_urls>", "contextMenus", "tabs"],
   "manifest_version": 2,
   "background": {
     "scripts": ["background.js"]

--- a/src/window/sidebar.py
+++ b/src/window/sidebar.py
@@ -93,8 +93,8 @@ def window_create_sidebar(self, variaapp, variaVersion):
     box_add_download.set_margin_top(8)
     box_add_download.set_margin_bottom(8)
 
-    download_entry = Gtk.Entry()
-    download_entry.set_placeholder_text(_("URL"))
+    self.download_entry = Gtk.Entry()
+    self.download_entry.set_placeholder_text(_("URL"))
 
     self.download_button_icon = Gtk.Image.new_from_icon_name("folder-download-symbolic")
     self.download_button_text = Gtk.Label(label=_("Download"))
@@ -106,7 +106,7 @@ def window_create_sidebar(self, variaapp, variaVersion):
     self.download_button.set_child(download_button_box)
     self.download_button.add_css_class("suggested-action")
     self.download_button.set_sensitive(False)
-    self.download_button.connect("clicked", on_download_clicked, self, download_entry, None, None, "regular", None, False, self.appconf["download_directory"])
+    self.download_button.connect("clicked", on_download_clicked, self, self.download_entry, None, None, "regular", None, False, self.appconf["download_directory"])
 
     self.video_button_icon = Gtk.Image.new_from_icon_name("camera-video-symbolic")
     self.video_button_text = Gtk.Label(label=_("Video / Audio"))
@@ -118,9 +118,9 @@ def window_create_sidebar(self, variaapp, variaVersion):
     self.video_button.set_child(video_button_box)
     self.video_button.add_css_class("suggested-action")
     self.video_button.set_sensitive(False)
-    self.video_button.connect("clicked", on_video_clicked, self, download_entry)
+    self.video_button.connect("clicked", on_video_clicked, self, self.download_entry)
 
-    download_entry.connect('changed', on_download_entry_changed, self.download_button, self.video_button)
+    self.download_entry.connect('changed', on_download_entry_changed, self.download_button, self.video_button)
 
     self.add_torrent_button = Gtk.Button()
     self.add_torrent_button.connect("clicked", on_add_torrent_clicked, self)
@@ -139,7 +139,7 @@ def window_create_sidebar(self, variaapp, variaVersion):
 
     self.add_torrent_button.set_child(self.torrent_button_box)
 
-    box_add_download.append(download_entry)
+    box_add_download.append(self.download_entry)
     box_add_download.append(self.download_button)
     box_add_download.append(self.video_button)
     box_add_download.append(Gtk.Separator(margin_top=8, margin_bottom=8))


### PR DESCRIPTION
Closes #178.
Partially closes #65.
Partially closes #90.

Adds a context menu button named "Download with Varia..." that sends the current tab URL to Varia to download as video/audio. Support is currently limited to YouTube (youtube.com/watch), but could be easily expanded/customizable.