### PR TITLE
Minimum download size in extension

### DIFF
--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -8,19 +8,41 @@ chrome.runtime.onInstalled.addListener(function(details) {
 
 chrome.downloads.onCreated.addListener(function(downloadItem) {
   var downloadTime = new Date(downloadItem.startTime).getTime();
-  var downloadSize = downloadItem.fileSize;
+  const id = downloadItem.id;
+  const maxRetries = 5;
+  const retryDelay = 200;
 
   if (downloadTime < startTime) {
     return;
   }
 
-  chrome.storage.sync.get(['enabled', 'downloadSize'], function(data) {
-    console.log('Min Download Size:', data.downloadSize || 0);
-    console.log('Download Size:', downloadSize);
-    if (data.enabled && downloadSize >= ((data.downloadSize || 0) * 1048576)) {
-      sendToAria2(downloadItem, "file");
-    }
-  });
+  // Firefox does not provide totalBytes immediately, so we need to wait for it to become available.
+
+  let retries = 0;
+
+  function checkDownloadSize() {
+    chrome.downloads.search({ id }, function(results) {
+      if (!results || results.length === 0) return;
+      const item = results[0];
+
+      if (item.totalBytes !== -1 || retries >= maxRetries) {
+        chrome.storage.sync.get(['enabled', 'downloadSize'], function(data) {
+          const minSize = (data.downloadSize || 0) * 1048576;
+          console.log('Min Download Size:', minSize);
+          console.log('Download Size:', item.totalBytes);
+
+          // Defaults to sending to Varia if totalBytes cannot be determined
+          if (data.enabled && (item.totalBytes >= minSize || retries >= maxRetries)) {
+            sendToAria2(item, "file");
+          }
+        });
+      } else {
+        retries++;
+        setTimeout(checkDownloadSize, retryDelay);
+      }
+    });
+  }
+  checkDownloadSize();
 });
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {

--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -8,12 +8,16 @@ chrome.runtime.onInstalled.addListener(function(details) {
 
 chrome.downloads.onCreated.addListener(function(downloadItem) {
   var downloadTime = new Date(downloadItem.startTime).getTime();
+  var downloadSize = downloadItem.fileSize;
+
   if (downloadTime < startTime) {
     return;
   }
 
-  chrome.storage.sync.get('enabled', function(data) {
-    if (data.enabled) {
+  chrome.storage.sync.get(['enabled', 'downloadSize'], function(data) {
+    console.log('Min Download Size:', data.downloadSize || 0);
+    console.log('Download Size:', downloadSize);
+    if (data.enabled && downloadSize >= ((data.downloadSize || 0) * 1048576)) {
       sendToAria2(downloadItem, "file");
     }
   });

--- a/browser-extension/popup.html
+++ b/browser-extension/popup.html
@@ -8,6 +8,8 @@
         background-color: #f6f5f4;
         border-radius: 8px;
         box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+        font-family: 'Adwaita Sans', Arial, Helvetica, sans-serif;
+        font-size: 75%;
       }
       .with-drop-shadow {
         filter: drop-shadow(rgb(122, 122, 122) 0rem 0rem 5px);

--- a/browser-extension/popup.html
+++ b/browser-extension/popup.html
@@ -4,7 +4,7 @@
     <style>
       body {
         width: 200px;
-        height: 240px;
+        height: 320px;
         background-color: #f6f5f4;
         border-radius: 8px;
         box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
@@ -76,6 +76,7 @@
       }
       @media (prefers-color-scheme: dark) {
         body {
+          color: white;
           background-color: #242424;
         }
         .with-drop-shadow {
@@ -110,6 +111,13 @@
       <label class="switch">
         <input type="checkbox" id="toggleSwitch">
         <span class="slider"></span>
+      </label>
+      <br><br>
+      <hr><br>
+      <label class="number">
+        <span>Minimum Download Size (MiB):</span>
+        <br><br>
+        <input type="number" id="downloadSize" min="0">
       </label>
       <br><br>
       <hr><br>

--- a/browser-extension/popup.js
+++ b/browser-extension/popup.js
@@ -1,11 +1,19 @@
 document.addEventListener('DOMContentLoaded', function () {
   var toggleSwitch = document.getElementById('toggleSwitch');
-  chrome.storage.sync.get('enabled', function(data) {
+  var downloadSizeInput = document.getElementById('downloadSize');
+
+  chrome.storage.sync.get(['enabled', 'downloadSize'], function(data) {
     toggleSwitch.checked = data.enabled;
+    downloadSizeInput.value = data.downloadSize || 0;
   });
+
   toggleSwitch.addEventListener('change', function () {
     var enabled = this.checked;
     chrome.storage.sync.set({enabled: enabled});
+  });
+  downloadSizeInput.addEventListener('change', function () {
+    var downloadSize = this.value;
+    chrome.storage.sync.set({downloadSize: downloadSize});
   });
 });
 


### PR DESCRIPTION
Added support for configuring a minimum download size in the extension. Saw this as a [suggestion in the Chrome Web Store](https://chromewebstore.google.com/reviews/180f7106-7409-40c8-8ecc-231f10f4fd61) and thought it'd be a useful addition.

Screenshot:
<img width="219" height="342" alt="image" src="https://github.com/user-attachments/assets/d3494297-d3d5-48b5-81b7-f3b031e673a2" />

Tested and working in Chromium 138.0.7204.184 and Firefox 141.0.