### PR TITLE
Magnet metadata stall

### DIFF
--- a/src/download/thread.py
+++ b/src/download/thread.py
@@ -228,7 +228,7 @@ class DownloadThread(threading.Thread):
 
                         self.selection_event = threading.Event()
                         from download.torrent_select_files import torrent_select_files_dialog
-                        torrent_select_files_dialog(self)
+                        GLib.idle_add(torrent_select_files_dialog, self)
 
                         self.selection_event.wait()
 

--- a/src/download/thread.py
+++ b/src/download/thread.py
@@ -220,7 +220,7 @@ class DownloadThread(threading.Thread):
 
                     self.update_labels_and_things(None)
 
-                    if self.download.is_torrent and len(self.download.files) > 0 and not self.torrent_file_select_completed:
+                    if self.download.is_torrent and not self.download.is_metadata and len(self.download.files) > 0 and not self.torrent_file_select_completed:
                         try:
                             self.download.pause()
                         except:


### PR DESCRIPTION
# Magnet links permanently stalls

### Summary

Magnet links (e.g. CachyOS ISO magent link) always stall at the metadata-fetching stage and never start downloading. Direct `.torrent` file downloads work. Root cause is the file-select dialog being triggered on the metadata download. Patching that exposes two further issues: the file-select dialog is constructed in a worker thread (GTK4 thread-safety violation), and failed attempts leave `.varia` state files that get re-added on every startup, duplicating downloads endlessly and flooding with aria2 error 12.

**Bug 1:** file-select dialog fires on the metadata download every magnet stalls

**Fix:** Guard the trigger with aria2p's existing `is_metadata` property (already used in `listen.py`):

**Verification:** with this change, magnet metadata resolved and the followed-by torrent download is picked up.

**Bug 2:** file-select dialog is built in a worker thread (Gtk-CRITICAL, crashes)

With Bug 1 fixed, magnets reach the file-select dialog and intermittently crashes. Any `.torrent` download that triggers the dialog is exposed to the same problem; magnets simply could not reach this code before Bug 1 was fixed. Probably related to Varia opening to system tray automatically.

**Fix:** The worker thread already synchronizes on `self.selection_event.wait()`, so the entire dialog construction can be deferred to the main loop:

**Bug 3:** stale `.varia` state files multiply failed downloads (aria2 error 12 flood)

`save_state()` in `thread.py` writes `<gid>.varia` into the download directory as soon as a download is added, and these are re-added on every startup. Combined with Bug 1, each failed magnet attempt leaves a new state file (new gid each time). After a few restarts:

- Startup re-adds the same magnet N times.
- aria2 rejects the duplicates with error 12 ("was downloading the same file"), shown as repeated "An error occurred: 12" rows.
- Each re-add writes yet another `.varia` file, so N grows on every restart.

From a single download I got 11 `.varia` files, 10+ duplicate `[METADATA]` entries all in ERR state, plus a 0-byte target file in the download directory.

**Suggested fixes:** remove the state file when a download errors out (not only on completion/cancel), and/or deduplicate by URL/info hash when restoring state at startup.

### Environment

- Varia 2026.3.27 (Arch Linux package)
- aria2 1.37 via RPC, torrenting enabled, GTK4/libadwaita on Wayland
