### PR TITLE
Fix crash when speed limit is set to MB/s or GB/s

### DIFF
--- a/src/download/communicate.py
+++ b/src/download/communicate.py
@@ -34,9 +34,9 @@ def set_speed_limit(self, download_limit):
     if download_limit.endswith("K"):
         lt_download_limit = int(download_limit.replace("K", "")) * 1024
     elif download_limit.endswith("M"):
-        lt_download_limit = int(download_limit.replace("K", "")) * 1024 * 1024
+        lt_download_limit = int(download_limit.replace("M", "")) * 1024 * 1024
     elif download_limit.endswith("G"):
-        lt_download_limit = int(download_limit.replace("K", "")) * 1024 * 1024 * 1024
+        lt_download_limit = int(download_limit.replace("G", "")) * 1024 * 1024 * 1024
 
     self.ltsession.apply_settings({
         "download_rate_limit": lt_download_limit,


### PR DESCRIPTION
Setting speed limit byte type to MB/s or GB/s crashes the app on every startup. The M and G branches in set_speed_limit() were copy-pasted from the K branch and still call .replace("K", ""), so "4M" stays "4M" and int("4M") throws:

    ValueError: invalid literal for int() with base 10: '4M'

KB/s works fine. The aria2 side is fine too since it takes "4M" natively, only the libtorrent conversion breaks.

Steps to reproduce:
1. Preferences -- Speed Limit, enable it, type a value, pick MB/s or GB/s
2. App crashes. Relaunch -- crashes again before the window shows.
